### PR TITLE
Add discussion-to header to CIP-3

### DIFF
--- a/cips/cip-3.md
+++ b/cips/cip-3.md
@@ -1,9 +1,10 @@
 ---
 cip: 3
-title: Setup Input 
+title: Setup Input
 status: Draft
 type: Core
 author: [Felipe Argento](felipe.argento@cartesi.io), [Guilherme Dantas](guilherme.dantas@cartesi.io), [Augusto Teixeira](augusto.teixeira@cartesi.io)
+discussions-to: https://github.com/cartesi/cips/discussions/8
 created: 2022-03-09
 ---
 


### PR DESCRIPTION
Adding the discussion-to header to CIP-3 as our CIP master @fcecin requested! Also created the [discussion post](https://github.com/cartesi/cips/discussions/8) on the governance forum :)