### PR TITLE
Cip backwards renaming

### DIFF
--- a/cips/CR6.md
+++ b/cips/CR6.md
@@ -1,5 +1,5 @@
 ---
-cip: 3
+cip: CR6
 title: Setup Input
 status: Draft
 type: Core

--- a/cips/IN2.md
+++ b/cips/IN2.md
@@ -1,6 +1,6 @@
 ---
-cip: 2
-title: The Cartesi Foundation and the CIP 
+cip: IN2
+title: The Cartesi Foundation and the CIP
 status: Final
 type: Informational
 author: The Cartesi Foundation <https://cartesi.io>

--- a/cips/MC23.md
+++ b/cips/MC23.md
@@ -1,5 +1,5 @@
 ---
-cip: 7
+cip: MC23
 title: MC - Increase CIP Identifier Expressiveness
 status: Draft
 type: Meta

--- a/cips/cip-1.md
+++ b/cips/cip-1.md
@@ -156,6 +156,7 @@ If you are interested in assuming ownership of a CIP, send a message asking to t
 The current CIP editors are
 
 - Fabiana Cecin (@fcecin)
+- Felipe Argento (@felipeargento)
 
 ## CIP Editor Responsibilities
 


### PR DESCRIPTION
- Renamed CIPs based on CIP MC23. 
- Added myself as a CIP editor.

Should I add a 0 between the letters and number? Or maybe MC#23? I don't know if it is because the numbers are still small, but it looks a bit odd to me.

The other thing is, should we separate the different types of CIPs in folder structures? One directory for Core, one for Meta etc?