### PR TITLE
CIP for non-technical CIPs

### DIFF
--- a/cips/cip-34.md
+++ b/cips/cip-34.md
@@ -1,0 +1,25 @@
+## **Abstract**
+
+This Informational CIP is a public declaration by the Cartesi Foundation that it will commit to supporting an additional category of CIPs for non-technical ecosystem improvements, subject to reasonable exceptions. 
+
+
+## **Motivation**
+
+The CIP process as described in [CIP-1](https://github.com/cartesi/cips/blob/main/cips/cip-1.md) describes four types of CIPs (core, application, meta, and informational), all of which are primarily centered around governance over technical aspects of the Cartesi technology. Through [CIP-2](https://github.com/cartesi/cips/blob/main/cips/cip-2.md), the Cartesi Foundation committed to supporting technical standards produced through the CIP process.
+
+Broader ecosystem initiatives, such as vision, adoption, marketing, community treasury allocation, developer relations, and more, generally fall outside the scope of the formal process set out in CIP-1.  As such, there is not yet any formalized governance mechanism for non-technical ecosystem improvements. 
+
+
+## **Specification**
+
+Building on its commitment in CIP-2, the Cartesi Foundation is committing to support non-technical improvement proposals that reach a community consensus, to the extent allowed by its charter, mandate, and material abilities, unless there are strong and thoroughly documented reasons for the Cartesi Foundation to not be an active participant in implementing a non-technical CIP.
+
+
+## **Rationale**
+
+The Cartesi Foundation has a mandate to support the development, decentralization, and adoption of the Cartesi technology and ecosystem.  Critical to that mandate is a commitment to decentralizing governance over non-technical aspects of the ecosystem.  Consistent with its mandate, the Cartesi Foundation has decided to memorialize its commitment to supporting non-technical CIPs as described herein.
+
+
+## **Risk Considerations**
+
+The Cartesi Foundation will not endeavor to support non-technical CIPs that, in the Foundation’s reasonable judgment, introduce legal or regulatory risk to the Foundation or ecosystem, or otherwise stand to threaten the Foundation’s own organizational health or the long-term sustainability of the Cartesi project.  Any decisions by the Cartesi Foundation to not support a non-technical CIP based on risk considerations will be thoroughly and publicly documented.


### PR DESCRIPTION
## **Abstract**

This Informational CIP is a public declaration by the Cartesi Foundation that it will commit to supporting an additional category of CIPs for non-technical ecosystem improvements, subject to reasonable exceptions. 


## **Motivation**

The CIP process as described in [CIP-1](https://github.com/cartesi/cips/blob/main/cips/cip-1.md) describes four types of CIPs (core, application, meta, and informational), all of which are primarily centered around governance over technical aspects of the Cartesi technology. Through [CIP-2](https://github.com/cartesi/cips/blob/main/cips/cip-2.md), the Cartesi Foundation committed to supporting technical standards produced through the CIP process.

Broader ecosystem initiatives, such as vision, adoption, marketing, community treasury allocation, developer relations, and more, generally fall outside the scope of the formal process set out in CIP-1.  As such, there is not yet any formalized governance mechanism for non-technical ecosystem improvements. 


## **Specification**

Building on its commitment in CIP-2, the Cartesi Foundation is committing to support non-technical improvement proposals that reach a community consensus, to the extent allowed by its charter, mandate, and material abilities, unless there are strong and thoroughly documented reasons for the Cartesi Foundation to not be an active participant in implementing a non-technical CIP.


## **Rationale**

The Cartesi Foundation has a mandate to support the development, decentralization, and adoption of the Cartesi technology and ecosystem.  Critical to that mandate is a commitment to decentralizing governance over non-technical aspects of the ecosystem.  Consistent with its mandate, the Cartesi Foundation has decided to memorialize its commitment to supporting non-technical CIPs as described herein.


## **Risk Considerations**

The Cartesi Foundation will not endeavor to support non-technical CIPs that, in the Foundation’s reasonable judgment, introduce legal or regulatory risk to the Foundation or ecosystem, or otherwise stand to threaten the Foundation’s own organizational health or the long-term sustainability of the Cartesi project.  Any decisions by the Cartesi Foundation to not support a non-technical CIP based on risk considerations will be thoroughly and publicly documented.
